### PR TITLE
Enable reading of encrypted PDFs by pdf-lib

### DIFF
--- a/watermark.js
+++ b/watermark.js
@@ -9,7 +9,7 @@ async function PDFWatermark(options) {
   }
 
   // load pdf
-  const document = await PDFDocument.load(readFileSync(pdf_path));
+  const document = await PDFDocument.load(readFileSync(pdf_path), {ignoreEncryption: true});
 
   //   get pages and number of pages
   const pages = document.getPages();


### PR DESCRIPTION
Watermarks still apply fine on encrypted documents as we have tested this change on 135k files dataset. This change enables pdf-lib to open the files, otherwise an error is thrown and the watermark is not applied to the file.